### PR TITLE
Allow scanning http:// URLs

### DIFF
--- a/bin/scanner.php
+++ b/bin/scanner.php
@@ -4,7 +4,7 @@
  * A (quick and dirty) scanner to scanning all (linked) pages of an https-enabled website for Mixed Content
  * @author Bramus! <bramus@bram.us>
  * @version 1.0
- * 
+ *
  * NO NEED TO TOUCH THIS FILE ... PLEASE REFER TO THE README.MD FILE ;-)
  */
 
@@ -16,7 +16,7 @@ ini_set('display_errors', 'off');
 if (php_sapi_name() != 'cli') exit('Please run this file on the command line. E.g. `php bin/scanner.php $url`' . PHP_EOL);
 
 // Check arguments (simple)
-if ($argc != 2 || !parse_url($argv[1]) || parse_url($argv[1])['scheme'] != 'https') exit('Please add a https:// URL you wish to scan as a parameter to this script. Eg. `php bin/scanner.php https://www.bram.us/`' . PHP_EOL);
+if ($argc != 2 || !parse_url($argv[1])) exit('Please use a valid URL you wish to scan as a parameter to this script. Eg. `php bin/scanner.php https://www.bram.us/`' . PHP_EOL);
 
 // Require needed Scanner class
 require __DIR__ . '/../src/Bramus/MCS/Scanner.php';


### PR DESCRIPTION
This makes it possible to use mixed-content-scan on websites that have not yet switched to HTTPS. Useful to prepare for HTTPS deployments!
