### PR TITLE
Add --json option for JSON formatted output

### DIFF
--- a/bin/mixed-content-scan
+++ b/bin/mixed-content-scan
@@ -24,7 +24,8 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) { // Installed Locally
 
 
 // Check arguments (simple)
-if ($argc != 2 || !parse_url($argv[1])) exit('Please use a valid URL you wish to scan as a parameter to this script. Eg. `php bin/scanner.php https://www.bram.us/`' . PHP_EOL);
+if (!($argc == 2 || $argc == 3) || !parse_url($argv[1])) exit('Please use a valid URL you wish to scan as a parameter to this script. Eg. `php bin/scanner.php https://www.bram.us/`' . PHP_EOL);
+if ($argc == 3 && !($argv[2] == "--json")) exit('The only acceptable extra argument is --json.' . PHP_EOL);
 
 // Get ignorepatterns
 $ignorePatterns = include __DIR__ . '/../conf/ignorePatterns.php';
@@ -32,7 +33,13 @@ $ignorePatterns = include __DIR__ . '/../conf/ignorePatterns.php';
 // Create logger
 $logger = new \Monolog\Logger('MCS');
 $handler = new \Monolog\Handler\StreamHandler('php://stdout', 200);
-$handler->setFormatter(new \Bramus\Monolog\Formatter\ColoredLineFormatter());
+
+if ($argc == 3 && ($argv[2] == "--json"))
+  $handler->setFormatter(new \Monolog\Formatter\JsonFormatter());
+else
+  $handler->setFormatter(new \Bramus\Monolog\Formatter\ColoredLineFormatter());
+
+
 $logger->pushHandler($handler);
 
 // Go for it!


### PR DESCRIPTION
This adds an optional `--json` flag as the final CLI argument, which triggers JSON formatting output instead of colored line output. It's newline-separated, streaming JSON objects.

```bash
mixed-content-scan http://leah.io --json

{"message":"Scanning https:\/\/leah.io\/","context":[],"level":250,"level_name":"NOTICE","channel":"MCS","datetime":{"date":"2015-02-06 00:54:13.881187","timezone_type":3,"timezone":"America\/New_York"},"extra":[]}
{"message":"cURL Error (7): Failed to connect to leah.io port 443: Connection timed out","context":[],"level":500,"level_name":"CRITICAL","channel":"MCS","datetime":{"date":"2015-02-06 00:54:21.611363","timezone_type":3,"timezone":"America\/New_York"},"extra":[]}
{"message":"00000 - https:\/\/leah.io\/","context":[],"level":200,"level_name":"INFO","channel":"MCS","datetime":{"date":"2015-02-06 00:54:21.612035","timezone_type":3,"timezone":"America\/New_York"},"extra":[]}
```

Fixes #14.