### PR TITLE
Return process error code on exception

### DIFF
--- a/bin/mixed-content-scan
+++ b/bin/mixed-content-scan
@@ -144,7 +144,7 @@ try {
     if (sizeof($urlsToQueue) > 0) $scanner->queueUrls($urlsToQueue);
     $scanner->scan();
 } catch(\Exception $e) {
-    exit();
+    exit(1);
 }
 
 // EOF


### PR DESCRIPTION
This makes the process return an exit code of 1 (error) if an exception is thrown/caught. This allows other programs depending on `mixed-content-scan` to change their behavior based on whether the scan ran properly or not.

There are a bunch of other exit calls which should also use an exit code of 1, some of which use `exit("string")` and would need to be converted to use `$logger->addEmergency()` for the exit message followed by an `exit(1)`. Because of my lack of PHP experience and the lack of a test suite in this repo, I didn't do do a comprehensive update to do that. This tweak tackles the common case and I've verified it works as promised.