### PR TITLE
Added timeout parameter. Allow missing certificates.

### DIFF
--- a/bin/mixed-content-scan
+++ b/bin/mixed-content-scan
@@ -31,6 +31,7 @@ $cli->description('Scan your HTTPS-enabled website for Mixed Content.')
     ->opt('format', 'Output format to use. Allowed values: `ansi`, `no-ansi`, or `json`. Defaults to `ansi`', false)
     ->opt('no-crawl', 'Don\'t crawl scanned pages for new pages.', false)
     ->opt('no-check-certificate', 'Don\'t check the certificate for validity.', false)
+    ->opt('timeout', 'How long to wait for each request to complete. Defaults to 10000ms.', false, 'integer')
     ->opt('input', 'Specify a file containing a list of links as the source, instead of parsing the passed in URL. Automatically enables `--no-crawl`', false)
     ->opt('ignore', 'File containing URL patterns to ignore. See readme shipping with release on how to build this file.', false)
     ->arg('rootUrl', 'The URL to start scanning at', false);
@@ -138,17 +139,29 @@ if (isset($opts['no-crawl'])) {
     $crawl = true;
 }
 
-// Do we need to crawl or not?
+// Do we need to check the certificate or not?
 if (isset($opts['no-check-certificate'])) {
     $checkCertificate = false;
 } else {
     $checkCertificate = true;
 }
 
+// Set the timeout value for each request
+if (isset($opts['timeout'])) {
+    $timeout = $opts['timeout'];
+    if (!(is_numeric($timeout) && $timeout > 0 && $timeout == round($timeout, 0))) {
+        $timeout = 10000;
+        $logger->addNotice('Invalid timeout value specified. Using default value of 10000ms.');
+    }
+} else {
+    $timeout = 10000;
+}
+
 // Go for it!
 try {
     $scanner = new \Bramus\MCS\Scanner($rootUrl, $logger, (array) $ignorePatterns);
     $scanner->setCrawl($crawl);
+    $scanner->setTimeout($timeout);
     $scanner->setCheckCertificate($checkCertificate);
     if (sizeof($urlsToQueue) > 0) $scanner->queueUrls($urlsToQueue);
     $scanner->scan();

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,8 @@ Mixed Content Scan support several CLI options which can manipulate its behavior
     - `no-ansi`: Monolog Line Formatter
     - `json`: Monolog JSON Formatter
 - `--no-crawl`: Don't crawl scanned pages for new pages
-- `--no-check-certificate`: Don\'t check the certificate for validity (e.g. allow self-signed ones)
+- `--no-check-certificate`: Don\'t check the certificate for validity (e.g. allow self-signed or missing certificates)
+- `--timeout=value-in-milliseconds`: How long to wait for each request to complete. Defaults to 10000ms.
 - `--input=path/to/file`: Specify a file containing a list of links as the source, instead of parsing the passed in URL. Automatically enables `--no-crawl`
 - `--ignore=path/to/file`: File containing URL patterns to ignore. See _Ignoring links_ further down on how to build this file.
 - `--loglevel=level`: The Monolog loglevel to log at. Defaults to `200`. See [Monolog Log Levels](https://github.com/Seldaek/monolog#log-levels) for more info.

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -15,10 +15,16 @@ class Scanner
     private $crawl = true;
 
     /**
-     * Do we check the certificates for being valid or not (true = allow self signed)
+     * Do we check the certificates for being valid or not (false = allow self signed, or missing certificates)
      * @var boolean
      */
     private $checkCertificate = true;
+
+    /**
+     * How long we will wait (in milliseconds) for each request to execute.
+     * @var int
+     */
+    private $timeout = 10000;
 
     /**
      * Logger
@@ -357,8 +363,9 @@ class Scanner
             CURLOPT_FOLLOWLOCATION => 1,
             CURLOPT_HEADER => 1, // Return both response head and response body, not only the response body
             CURLOPT_URL => $pageUrl,
-            CURLOPT_TIMEOUT_MS => 10000,
-            CURLOPT_SSL_VERIFYPEER => $this->checkCertificate
+            CURLOPT_TIMEOUT_MS => $this->timeout,
+            CURLOPT_SSL_VERIFYPEER => $this->checkCertificate,
+            CURLOPT_SSL_VERIFYHOST => $this->getVerifyHost(),
         ));
 
         // Fetch the response (both head and body)
@@ -428,7 +435,7 @@ class Scanner
      * Get checkCertificate value
      * @return boolean
      */
-    public function getCheckCertifate()
+    public function getCheckCertificate()
     {
         return $this->checkCertificate;
     }
@@ -440,5 +447,36 @@ class Scanner
     public function setCheckCertificate($checkCertificate)
     {
         $this->checkCertificate = (bool) $checkCertificate;
+    }
+
+    /**
+     * Get verifyHost value
+     * @return int
+     */
+    public function getVerifyHost()
+    {
+        if ($this->checkCertificate) {
+            return 2;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Get timeout value
+     * @return int
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Set timeout value
+     * @param int
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
     }
 }


### PR DESCRIPTION
In the environment I was testing on, some pages took longer than 10000 ms to load, so I made this CURL parameter configurable.

I also wanted to be able to test on my local environment where no certificate was setup at all. I adopted the 'no-check-certificate' parameter to allow this situation. I did consider adding a new parameter, but thought this would complicate the command.
Also, judging by the name,  'no-check-certificate' , I think allowing no certificates at all makes sense too.