### PR TITLE
Fix README typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Mixed Content Scan support several CLI options which can manipulate its behavior
 - `--ignore=path/to/file`: File containing URL patterns to ignore. See _Ignoring links_ further down on how to build this file.
 - `--loglevel=level`: The Monolog loglevel to log at. Defaults to `200`. See [Monolog Log Levels](https://github.com/Seldaek/monolog#log-levels) for more info.
 
-Example: `mixed-content-scan https://www.bram.us/ --ingore=./wordpress.txt --output=./results.txt --format=no-ansi`
+Example: `mixed-content-scan https://www.bram.us/ --ignore=./wordpress.txt --output=./results.txt --format=no-ansi`
 
 ## Handling errors
 


### PR DESCRIPTION
Typo in code example