### PR TITLE
Ignore empty context and extra arrays

### DIFF
--- a/bin/mixed-content-scan
+++ b/bin/mixed-content-scan
@@ -51,7 +51,7 @@ if (!isset($opts['format'])) $opts['format'] = 'ansi';
 switch($opts['format']) {
 
     case 'no-ansi':
-        $formatter = new \Monolog\Formatter\LineFormatter();
+        $formatter = new \Monolog\Formatter\LineFormatter(null, null, false, true);
         break;
 
     case 'json':
@@ -60,7 +60,7 @@ switch($opts['format']) {
 
     case 'ansi':
     default:
-        $formatter = new \Bramus\Monolog\Formatter\ColoredLineFormatter();
+        $formatter = new \Bramus\Monolog\Formatter\ColoredLineFormatter(null, null, null, false, true);
         break;
 
 }


### PR DESCRIPTION
Removing the unused context and extra arrays from log lines makes the entries cleaner and easier to read IMO:

![screenshot 2016-12-01 00 36 48](https://cloud.githubusercontent.com/assets/88371/20777329/3eb5af4a-b75e-11e6-85f8-2ad2fd191148.png)

There may be some concern minor concern about a change in how these entries might be machine parsed, but in that case, I'd expect folks to be outputting using the `json` format instead of `ansi` or `no-ansi`.