### PR TITLE
Don't force a trailing slash on file extensions

### DIFF
--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -115,9 +115,12 @@ class Scanner
             throw new Exception('Invalid rootUrl!');
         }
 
-        // Force trailing / on rootUrl, it's easier for us to work with it
-        if (substr($rootUrl, -1) !== '/') {
-            $rootUrl .= '/';
+        // Force trailing / on rootUrl unless it has a file extension, it's easier for us to work with it
+        $rootUrlPath = explode('/', parse_url($rootUrl)['path']);
+        if (strpos(array_reverse($rootUrlPath)[0], '.') === false) {
+            if (substr($rootUrl, -1) !== '/') {
+                $rootUrl .= '/';
+            }
         }
 
         // store rootUrl
@@ -494,3 +497,4 @@ class Scanner
         $this->timeout = $timeout;
     }
 }
+


### PR DESCRIPTION
If you force the trailing slash on https://www.example.com/example/index.html, the curled page 404s, and you scan the 404 page instead of the desired page.

This could also allow for scanning css and js files down the line.