### PR TITLE
Add option to set the user agent when crawling

### DIFF
--- a/bin/mixed-content-scan
+++ b/bin/mixed-content-scan
@@ -34,6 +34,7 @@ $cli->description('Scan your HTTPS-enabled website for Mixed Content.')
     ->opt('timeout', 'How long to wait for each request to complete. Defaults to 10000ms.', false, 'integer')
     ->opt('input', 'Specify a file containing a list of links as the source, instead of parsing the passed in URL. Automatically enables `--no-crawl`', false)
     ->opt('ignore', 'File containing URL patterns to ignore. See readme shipping with release on how to build this file.', false)
+    ->opt('user-agent', 'Set the user agent to be used when crawling', false)
     ->arg('rootUrl', 'The URL to start scanning at', false);
 
 // Parse and return cli options
@@ -166,12 +167,20 @@ if (isset($opts['timeout'])) {
     $timeout = 10000;
 }
 
+// Set the user agent to use when crawling
+if (isset($opts['user-agent'])) {
+    $userAgent = $opts['user-agent'] .' mixed-content-scan';
+} else {
+    $userAgent = 'mixed-content-scan';
+}
+
 // Go for it!
 try {
     $scanner = new \Bramus\MCS\Scanner($rootUrl, $logger, (array) $ignorePatterns);
     $scanner->setCrawl($crawl);
     $scanner->setTimeout($timeout);
     $scanner->setCheckCertificate($checkCertificate);
+    $scanner->setUserAgent($userAgent);
     if (sizeof($urlsToQueue) > 0) $scanner->queueUrls($urlsToQueue);
     $scanner->scan();
 } catch(\Exception $e) {

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -379,7 +379,7 @@ class Scanner
             CURLOPT_TIMEOUT_MS => $this->timeout,
             CURLOPT_SSL_VERIFYPEER => $this->checkCertificate,
             CURLOPT_SSL_VERIFYHOST => $this->getVerifyHost(),
-            CURLOPT_USERAGENT => 'mixed-content-scan',
+            CURLOPT_USERAGENT => $this->getUserAgent(),
         ]);
 
         // Fetch the response (both head and body)
@@ -492,5 +492,23 @@ class Scanner
     public function setTimeout($timeout)
     {
         $this->timeout = $timeout;
+    }
+
+    /**
+     * Get user agent value
+     * @return string
+     */
+    public function getUserAgent()
+    {
+        return $this->userAgent;
+    }
+
+    /**
+     * Set user agent value
+     * @param string
+     */
+    public function setUserAgent($userAgent)
+    {
+        $this->userAgent = $userAgent;
     }
 }


### PR DESCRIPTION
We often need to scan content on sites that load different templates based on the device requesting the page, so it is very useful to pass a user agent when initiating the crawl.

### Usage
`mixed-content-scan https://www.securesite.com --user-agent="Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"`

You will see that no matter what user agent you pass, the `mixed-content-scan` string will get appended so it is possible to exclude these visits from any log files if you need to.

Thanks
