### PR TITLE
Fix for checking link tag is a stylesheet

### DIFF
--- a/src/DOMDocument.php
+++ b/src/DOMDocument.php
@@ -62,6 +62,11 @@ class DOMDocument extends \DOMDocument
         foreach ($this->tags as $tag => $attributes) {
             /** @var \DOMElement $el */
             foreach ($this->getElementsByTagName($tag) as $el) {
+                
+                if ($tag == 'link' && $el->hasAttribute('rel') && ($el->getAttribute('rel') !== 'stylesheet')) {
+                    continue;
+                }
+                
                 /** @var array $attributes */
                 foreach ($attributes as $attribute) {
                     if ($el->hasAttribute($attribute)) {


### PR DESCRIPTION
Possible quickfix for https://github.com/bramus/mixed-content-scan/issues/44. I'm sorry this bug was introduced; I'm not sure of a better way to handle these exceptions.