### PR TITLE
Look into image that are lazy-loaded via data-src attribute

### DIFF
--- a/src/DOMDocument.php
+++ b/src/DOMDocument.php
@@ -18,7 +18,7 @@ class DOMDocument extends \DOMDocument
         'embed'  => ['src'],
         'form'   => ['action'],
         'iframe' => ['src'],
-        'img'    => ['src', 'srcset'],
+        'img'    => ['src', 'srcset', 'data-src'],
         'link'   => ['href'],
         'object' => ['data'],
         'param'  => ['value'],


### PR DESCRIPTION
Without this patch:
0 error found on: https://abc-securite.installateur-alarme-proxeo.fr/

But there are 8 mixed content problems just on this page. It's because our images are lazy-loaded via the common `data-src` attribute and this lib isn't checking it yet. ;-)